### PR TITLE
Update retrieve-contrasts.sh

### DIFF
--- a/bin/retrieve-contrasts.sh
+++ b/bin/retrieve-contrasts.sh
@@ -16,7 +16,7 @@ fetchStatus=$?
 grep -q '<html>' $contrastdetails
 errorStatus=$?
 
-if [ $fetchStatus? -ne 0 ] || [ $errorStatus -eq 0 ]; then
+if [ $fetchStatus -ne 0 ] || [ $errorStatus -eq 0 ]; then
     echo "ERROR: Failed to retrieve $stagingApiUrl/contrastdetails.tsv" 1>&2
     rm -rf $contrastdetails
     exit 1
@@ -28,7 +28,7 @@ fetchStatus=$?
 grep -q '<html>' $assaygroupsdetails
 errorStatus=$?
 
-if [ $fetchStatus? -ne 0 ] || [ $errorStatus -eq 0 ]; then
+if [ $fetchStatus -ne 0 ] || [ $errorStatus -eq 0 ]; then
     echo "ERROR: Failed to retrieve $stagingApiUrl/assaygroupsdetails.tsv" 1>&2
     rm -rf $assaygroupsdetails
     exit 1

--- a/bin/retrieve-contrasts.sh
+++ b/bin/retrieve-contrasts.sh
@@ -29,7 +29,7 @@ grep -q '<html>' $assaygroupsdetails
 errorStatus=$?
 
 if [ $fetchStatus? -ne 0 ] || [ $errorStatus -eq 0 ]; then
-    echo "ERROR: Failed to retrieve $stagingApiUrl/assaygroupsdetails.tsv"
+    echo "ERROR: Failed to retrieve $stagingApiUrl/assaygroupsdetails.tsv" 1>&2
     rm -rf $assaygroupsdetails
     exit 1
 fi

--- a/bin/retrieve-contrasts.sh
+++ b/bin/retrieve-contrasts.sh
@@ -10,14 +10,25 @@ stagingApiUrl=${stagingApiUrl:-https://wwwdev.ebi.ac.uk/gxa/api}
 
 contrastdetails=$ATLAS_EXPS/contrastdetails.tsv
 curl -s -o $contrastdetails "$stagingApiUrl/contrastdetails.tsv"
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to retrieve $stagingApiUrl/contrastdetails.tsv"
+fetchStatus=$?
+
+# HTML in the tsv output spells trouble
+grep -q '<html>' $contrastdetails
+errorStatus=$?
+
+if [ $fetchStatus? -ne 0 ] || [ $errorStatus -eq 0 ]; then
+    echo "ERROR: Failed to retrieve $stagingApiUrl/contrastdetails.tsv" 1>&2
     rm -rf $contrastdetails
     exit 1
 fi
+
 assaygroupsdetails=$ATLAS_EXPS/assaygroupsdetails.tsv
 curl -s -o $assaygroupsdetails "$stagingApiUrl/assaygroupsdetails.tsv"
-if [ $? -ne 0 ]; then
+fetchStatus=$?
+grep -q '<html>' $assaygroupsdetails
+errorStatus=$?
+
+if [ $fetchStatus? -ne 0 ] || [ $errorStatus -eq 0 ]; then
     echo "ERROR: Failed to retrieve $stagingApiUrl/assaygroupsdetails.tsv"
     rm -rf $assaygroupsdetails
     exit 1


### PR DESCRIPTION
Currently we can have nonsense written to the contrasts and assay groups file (e.g. when there are issues in GXA), and curl doesn't report that as an issue. This PR addresses that.